### PR TITLE
Adds build wrapper script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build
+build: ## Builds all FPF containers.
+	DOCKER_CONTENT_TRUST=1 \
+		ansible-playbook -vv --diff playbook.yml

--- a/build-image.yml
+++ b/build-image.yml
@@ -1,0 +1,12 @@
+---
+- name: Load container config.
+  set_fact:
+    container_config: "{{ lookup('file', item+'/meta.yml')|from_yaml }}"
+
+- name: Build container image.
+  docker_image:
+    name: "{{ container_config.repo|basename }}"
+    force: "{{ container_config.force|default(omit) }}"
+    path: "{{ container_config.repo|basename }}"
+    state: present
+    tag: "{{ build_timestamp }}"

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,31 @@
+---
+- name: Build all FPF containers.
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+  tasks:
+    # Use set_fact to freeze the lookup value, so it's the same across images
+    # and used identically on all images built.
+    - name: Set build timestamp for use as image tag.
+      set_fact:
+        build_timestamp: "{{ lookup('pipe', 'date -u +%Y%m%d') }}"
+
+    - name: Find all container configs.
+      find:
+        paths:
+          - "{{ playbook_dir }}"
+        file_type: directory
+      register: find_container_config_results
+
+    - debug: var=find_container_config_results
+
+    - name: Set container name list as fact.
+      set_fact:
+        container_names: "{{ find_container_config_results.files|map(attribute='path')|map('basename')|list }}"
+
+    - debug: var=container_names
+
+    # Import separate task list to take advantage of `which_items` loop.
+    - include: build-image.yml
+      with_items: "{{ container_names }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ansible
+docker-py


### PR DESCRIPTION
Using an Ansible playbook to read in the YAML metadata for each container and kick off a build. Builds are tagged with timestamp of year, month, and day in UTC, e.g. `20170925`. Right now the playbook does *not* push images automatically, figured we should take it for a spin first.

Is it madness to use a Makefile to call Ansible to build Docker containers? Probably it is. Should we just use `docker-compose` to build and push these images? Probably we should. 

To test, run `make build` locally and confirm you get new images.