### PR TITLE
Adds Debian Jessie builder - for creating virtualenvs under django role

### DIFF
--- a/debian-jessie-venv/Dockerfile
+++ b/debian-jessie-venv/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:jessie
+
+LABEL maintainer="Freedom of the Press Foundation"
+
+RUN apt-get update &&\
+    apt-get install --no-install-recommends -y\
+        git gcc g++ python3 python3-dev virtualenv \
+        libxml2-dev libxslt-dev zlib1g-dev libjpeg-dev \
+        libpq-dev libffi-dev locales locales-all \
+        python sudo bash ca-certificates paxctl &&\
+    apt-get clean && rm -rf /var/lib/apt/lists/* &&\
+    rm -rf /usr/share/doc/ && rm -rf /usr/share/man &&\
+    rm -rf /usr/share/locale
+
+# http://bugs.python.org/issue19846
+# At the moment, setting "LANG=C" on a Linux system *fundamentally breaks py3
+ENV LANG C.UTF-8

--- a/debian-jessie-venv/meta.yml
+++ b/debian-jessie-venv/meta.yml
@@ -1,0 +1,4 @@
+---
+repo: "quay.io/freedomofpress/debian-jessie-venv"
+tag: "latest"
+digest: "sha256:9b128d0907cf0d395efac39d0d26322b4746ba7dbd51cf3770abbe0d33e21f1d"


### PR DESCRIPTION
This is optionally utilized in our ansible django role
(https://github.com/freedomofpress/ansible-role-django) during the virtualenv
build task.

Image has already been push to quay