### PR TITLE
Update logstash-verifier image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+playbook.retry

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+# Disable creation of .retry files on failed playbook runs.
+# Our playbooks aren't so big nor our hosts so numerous
+# that we can't just run the playbook again.
+retry_files_enabled = False

--- a/build-image.yml
+++ b/build-image.yml
@@ -5,8 +5,9 @@
 
 - name: Build container image.
   docker_image:
-    name: "{{ container_config.repo|basename }}"
+    name: "{{ container_config.repo }}"
     force: "{{ container_config.force|default(omit) }}"
     path: "{{ container_config.repo|basename }}"
     state: present
-    tag: "{{ build_timestamp }}"
+    tag: "{{ container_config.tag }}"
+    buildargs: "{{ container_config.args|default(omit) }}"

--- a/logstash-verifier/Dockerfile
+++ b/logstash-verifier/Dockerfile
@@ -1,55 +1,35 @@
-FROM msheiny/debian-jessie-systemd:latest
+FROM openjdk:8-jdk-slim-stretch
 
 MAINTAINER Freedom of the Press
-ENV GOPATH /tmp/logstash-filter-verifier
 
-ENV GOLANG_VERSION 1.8
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 53ab94104ee3923e228a2cb2116e5e462ad3ebaeea06ff04463479d7f12d27ca
-ENV GOROOT /usr/local/go
-ENV PATH $GOROOT/bin:$PATH
+ENV LS_VERIFIER_TAR https://github.com/magnusbaeck/logstash-filter-verifier/releases/download/1.4.1/logstash-filter-verifier_1.4.1_linux_amd64.tar.gz
+ENV LS_VERIFIER_SHA256 2c322c84d5a82532ee7aee56f06bb1046b62fe46a73e920be970301382decaf1
+ARG LS_VER
+
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        apt-transport-https \
-        binutils \
-        git \
-        make \
-        curl \
-        gnupg2 \
-        ca-certificates \
-        paxctl \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz && \
-    echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - && \
-    tar -C /usr/local -xzf golang.tar.gz && \
-    rm golang.tar.gz && \
-    mkdir $GOPATH && \
-    cd $GOPATH && \
-    go get -d github.com/magnusbaeck/logstash-filter-verifier && \
-    cd src/github.com/magnusbaeck/logstash-filter-verifier && \
-    make install && \
-    cd /tmp && \
-    rm -rf $GOPATH && \
-    rm -rf $GOROOT
-
-RUN apt-get update && apt-get install paxctld -y
+        curl paxctl gnupg2 apt-transport-https && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/cache/apt/*
 
 RUN curl -fs https://packages.elastic.co/GPG-KEY-elasticsearch | apt-key add - && \
-    echo "deb https://artifacts.elastic.co/packages/5.x/apt stable main" > /etc/apt/sources.list.d/elastic-5.x.list && \
-    echo "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java m" >> /etc/paxctld.conf && \
-    echo "/var/lib/dpkg/info/ca-certificates-java.postinst m" >> /etc/paxctld.conf && \
-    echo "/etc/ca-certificates/update.d/jks-keystore m" >> /etc/paxctld.conf && \
-    /etc/init.d/paxctld start && \
-    mkdir -p /usr/share/man/man1/ && \
-    apt-get update && \
-    apt-get install -y openjdk-8-jre-headless 2> /dev/null && \
-    apt-get install -y --allow-unauthenticated --no-install-recommends logstash && \
-    /usr/share/logstash/bin/logstash-plugin install logstash-filter-de_dot && \
-    rm -rf /var/lib/apt/lists/*
+    echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" > /etc/apt/sources.list.d/elastic.list && \
+    paxctl -cm /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java && \
+    apt-get update && apt-get install logstash=1:${LS_VER}-1 && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/cache/apt/*
+
+RUN cd /tmp && \
+    curl -sL $LS_VERIFIER_TAR -o ls-verifier.tar.gz && \
+    echo "$LS_VERIFIER_SHA256 ls-verifier.tar.gz" | sha256sum -c - && \
+    tar -C /usr/bin -xzf ls-verifier.tar.gz
+
+RUN chown logstash /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java && \
+    chown logstash: -R /etc/logstash
 
 ADD scripts/start-up.sh /run/startup.sh
 RUN chmod +x /run/startup.sh
+USER logstash
 
 ENTRYPOINT ["bash", "/run/startup.sh"]
 CMD ["grsecurity.json", "all"]

--- a/logstash-verifier/Dockerfile
+++ b/logstash-verifier/Dockerfile
@@ -24,6 +24,11 @@ RUN cd /tmp && \
     echo "$LS_VERIFIER_SHA256 ls-verifier.tar.gz" | sha256sum -c - && \
     tar -C /usr/bin -xzf ls-verifier.tar.gz
 
+# This is necessary because we are re-slapping the pax flags on java
+# during the entrypoint script at run-time. The logstash user needs write
+# permissions since the container is starting up as non-root.
+# For whatever reason (be it docker version or storage driver provider), the
+# pax flags set by root above does not persist onto the running image.
 RUN chown logstash /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java && \
     chown logstash: -R /etc/logstash
 

--- a/logstash-verifier/meta.yml
+++ b/logstash-verifier/meta.yml
@@ -1,3 +1,5 @@
 ---
 repo: "quay.io/freedomofpress/logstash-verifier"
-tag: "5.4.3"
+tag: "6.1.2"
+args:
+  LS_VER: "6.1.2"

--- a/logstash-verifier/scripts/start-up.sh
+++ b/logstash-verifier/scripts/start-up.sh
@@ -21,5 +21,5 @@ else
     CONFIG_PATH=/etc/logstash/conf.d/
 fi
 
-/usr/local/bin/logstash-filter-verifier --logstash-path=$LOGSTASH_PATH/logstash \
+/usr/bin/logstash-filter-verifier --logstash-path=$LOGSTASH_PATH/logstash \
     "/etc/logstash/tests/$1" "${CONFIG_PATH}/$2"

--- a/playbook.yml
+++ b/playbook.yml
@@ -16,13 +16,15 @@
         file_type: directory
       register: find_container_config_results
 
-    - debug: var=find_container_config_results
-
-    - name: Set container name list as fact.
+    - name: If user hit enter, build all containers
       set_fact:
         container_names: "{{ find_container_config_results.files|map(attribute='path')|map('basename')|list }}"
+      when: "container_to_build == 'all'"
 
-    - debug: var=container_names
+    - name: Set container names to user provided
+      set_fact:
+        container_names: ['{{ container_to_build }}']
+      when: "container_to_build != 'all'"
 
     # Import separate task list to take advantage of `which_items` loop.
     - include: build-image.yml

--- a/playbook.yml
+++ b/playbook.yml
@@ -3,14 +3,12 @@
   hosts: localhost
   connection: local
   gather_facts: no
-  vars:
+  vars_prompt:
+    - name: container_to_build
+      prompt: "Container name to build: "
+      private: no
+      default: all
   tasks:
-    # Use set_fact to freeze the lookup value, so it's the same across images
-    # and used identically on all images built.
-    - name: Set build timestamp for use as image tag.
-      set_fact:
-        build_timestamp: "{{ lookup('pipe', 'date -u +%Y%m%d') }}"
-
     - name: Find all container configs.
       find:
         paths:


### PR DESCRIPTION
So this PR does two things:
* updates the logstash-verifier image
* anddd updates a little bit of build logic

On the first issue, re-did the image completely based on an upstream openjdk image (MUCH easier build process with grsec), and did some re-engineering to try and make the image smaller (like grab upstream release package instead of compiling from source). I also tweaked the build entrypoint script so the image can be run as `logstash` user (🎉  without `root` ✨  ). 

So I also made some possible controversial changes to the build scripts. @conorsch need a ping here. FYI i've already built and pushed image `quay.io/freedomofpress/logstash-verifier:6.1.2` up and recorded that digest hash into the logstash-filters repo.