### PR TITLE
ES-HEAD w/ pax flag container

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "es-head-pax/src"]
+	path = es-head-pax/src
+	url = git@github.com:freedomofpress/elasticsearch-head.git

--- a/es-head-pax/Dockerfile
+++ b/es-head-pax/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:alpine
+WORKDIR /usr/src/app
+
+# Install pax tooling
+RUN apk add paxctl --no-cache  && \
+    paxctl -cm /usr/local/bin/node && \
+    chown node: /usr/local/bin/node
+
+RUN npm install http-server
+COPY src/ .
+EXPOSE 9100
+
+USER node
+CMD paxctl -cm /usr/local/bin/node && \
+    node_modules/http-server/bin/http-server _site -p 9100

--- a/es-head-pax/Dockerfile
+++ b/es-head-pax/Dockerfile
@@ -8,6 +8,8 @@ RUN apk add paxctl --no-cache  && \
 
 RUN npm install http-server
 COPY src/ .
+
+RUN chown node: -R /usr/src/app
 EXPOSE 9100
 
 USER node

--- a/es-head-pax/meta.yml
+++ b/es-head-pax/meta.yml
@@ -1,0 +1,3 @@
+---
+repo: "quay.io/freedomofpress/es-head-pax"
+tag: "6"


### PR DESCRIPTION
NOTE- This is based on changes made in  #6 - so review and merge that before this. The image has already been pushed to quay from here though.

This particularly PR focuses on building a container to run `es-head` (a node app), for debugging elasticsearch instances. Particular note was that upstream hasnt merged the 6.x fixes in and doesnt have support for running under grsec. Oh yeah I also defaulted the image to run the `node` user instead of `root`.

