### PR TITLE
Adds debian stretch builder image

### DIFF
--- a/debian-stretch-builder/Dockerfile
+++ b/debian-stretch-builder/Dockerfile
@@ -1,0 +1,13 @@
+# Debian 9.5
+FROM debian@sha256:f1f61086ea01a72b30c7287adee8c929e569853de03b7c462a8ac75e0d0224c4
+# additional meta-data makes it easier to clean up, find
+LABEL org="Freedom of the Press"
+LABEL image_name="stretch-builder"
+
+RUN apt-get -y update && apt-get upgrade -y && apt-get install -y \
+        build-essential \
+        debhelper \
+        python \
+        git \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*

--- a/debian-stretch-builder/meta.yml
+++ b/debian-stretch-builder/meta.yml
@@ -1,0 +1,3 @@
+---
+repo: "quay.io/freedomofpress/stretch-builder"
+tag: "latest"

--- a/debian-stretch-builder/meta.yml
+++ b/debian-stretch-builder/meta.yml
@@ -1,3 +1,3 @@
 ---
-repo: "quay.io/freedomofpress/stretch-builder"
+repo: "quay.io/freedomofpress/debian-stretch-builder"
 tag: "latest"


### PR DESCRIPTION
Based on the official debian 9.5 image, this image contains packages to
build debian packages via molecule. This is needed for https://github.com/freedomofpress/securedrop-workstation/issues/113