### PR TITLE
Add persistent configuration options to block apt redirects

### DIFF
--- a/debian-jessie-venv/Dockerfile
+++ b/debian-jessie-venv/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:jessie
 
 LABEL maintainer="Freedom of the Press Foundation"
 
+COPY config/00redirects /etc/apt/apt.conf.d/00redirects
 RUN apt-get update &&\
     apt-get install --no-install-recommends -y\
         git gcc g++ python3 python3-dev virtualenv \

--- a/debian-jessie-venv/config/00redirects
+++ b/debian-jessie-venv/config/00redirects
@@ -1,0 +1,1 @@
+Acquire::http:AllowRedirect=false;


### PR DESCRIPTION
This will fix the `debian-jessie-venv` container for the vulnerability in https://github.com/freedomofpress/infrastructure/issues/1581