### PR TITLE
Adds Ubuntu Xenial-based virtualenv builder

### DIFF
--- a/ubuntu-xenial-venv/Dockerfile
+++ b/ubuntu-xenial-venv/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:xenial
+
+LABEL maintainer="Freedom of the Press Foundation"
+
+COPY config/00redirects /etc/apt/apt.conf.d/00redirects
+RUN apt-get update &&\
+    apt-get install --no-install-recommends -y\
+        git gcc g++ python3 python3-dev virtualenv \
+        libxml2-dev libxslt-dev zlib1g-dev libjpeg-dev \
+        libpq-dev libffi-dev locales locales-all \
+        python sudo bash ca-certificates paxctl &&\
+    apt-get clean && rm -rf /var/lib/apt/lists/* &&\
+    rm -rf /usr/share/doc/ && rm -rf /usr/share/man &&\
+    rm -rf /usr/share/locale
+
+# http://bugs.python.org/issue19846
+# At the moment, setting "LANG=C" on a Linux system *fundamentally breaks py3
+ENV LANG C.UTF-8

--- a/ubuntu-xenial-venv/config/00redirects
+++ b/ubuntu-xenial-venv/config/00redirects
@@ -1,0 +1,1 @@
+Acquire::http:AllowRedirect=false;

--- a/ubuntu-xenial-venv/meta.yml
+++ b/ubuntu-xenial-venv/meta.yml
@@ -1,0 +1,4 @@
+---
+repo: "quay.io/freedomofpress/ubuntu-xenial-venv"
+tag: "latest"
+digest: "sha256:132f5164abac16b04d918547e4d0327bbd98a42ab33ef21d017d962cec2cb5aa"


### PR DESCRIPTION
In order to match target hosts, we need a build container for
virtualenvs of the same OS. Since we've been deploying to Xenial remotes
recently, let's store a Xenial container specifically for use with
managing Python virtualenvs.