### PR TITLE
Updates Jessie virtualenv builder

### DIFF
--- a/debian-jessie-venv/meta.yml
+++ b/debian-jessie-venv/meta.yml
@@ -1,4 +1,4 @@
 ---
 repo: "quay.io/freedomofpress/debian-jessie-venv"
 tag: "latest"
-digest: "sha256:9b128d0907cf0d395efac39d0d26322b4746ba7dbd51cf3770abbe0d33e21f1d"
+digest: "sha256:8dbb2e77422ad41836b9d39d4356ece323885b488b35b5e8c03a9c9c33e9beb4"


### PR DESCRIPTION
Unblocking updates to a straggling Jessie host. Manually tagged with
20190502 and pushed up. We'll soon be able to retire this image.