### PR TITLE
Updates logstash-verifier to LS 6.7.1

### DIFF
--- a/logstash-verifier/Dockerfile
+++ b/logstash-verifier/Dockerfile
@@ -8,13 +8,12 @@ ARG LS_VER
 
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl paxctl gnupg2 apt-transport-https && \
+        curl gnupg2 apt-transport-https && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 
 RUN curl -fs https://packages.elastic.co/GPG-KEY-elasticsearch | apt-key add - && \
     echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" > /etc/apt/sources.list.d/elastic.list && \
-    paxctl -cm /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java && \
     apt-get update && apt-get install logstash=1:${LS_VER}-1 && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
@@ -24,13 +23,7 @@ RUN cd /tmp && \
     echo "$LS_VERIFIER_SHA256 ls-verifier.tar.gz" | sha256sum -c - && \
     tar -C /usr/bin -xzf ls-verifier.tar.gz
 
-# This is necessary because we are re-slapping the pax flags on java
-# during the entrypoint script at run-time. The logstash user needs write
-# permissions since the container is starting up as non-root.
-# For whatever reason (be it docker version or storage driver provider), the
-# pax flags set by root above does not persist onto the running image.
-RUN chown logstash /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java && \
-    chown logstash: -R /etc/logstash
+RUN chown logstash: -R /etc/logstash
 
 ADD scripts/start-up.sh /run/startup.sh
 RUN chmod +x /run/startup.sh

--- a/logstash-verifier/meta.yml
+++ b/logstash-verifier/meta.yml
@@ -1,5 +1,5 @@
 ---
 repo: "quay.io/freedomofpress/logstash-verifier"
-tag: "6.1.2"
+tag: "6.7.1"
 args:
-  LS_VER: "6.1.2"
+  LS_VER: "6.7.1"

--- a/logstash-verifier/scripts/start-up.sh
+++ b/logstash-verifier/scripts/start-up.sh
@@ -5,8 +5,6 @@ set -e
 
 LOGSTASH_PATH=/usr/share/logstash/bin
 
-/sbin/paxctl -cm /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 2> /dev/null
-
 cd /etc/logstash/conf.d/ || exit
 
 # Exclude multiline and input and output logs


### PR DESCRIPTION
We recently bumped the ELK stack to 6.7.1, so let's ensure that we're
testing against the same version.

Technically this work duplicates what was previously done in https://github.com/freedomofpress/container-logstash-verifier, but since the `containers` repository is still the canonical reference for image builds, I'm submitting it here.