### PR TITLE
Logstash verifier - swap backend container

### DIFF
--- a/logstash-verifier/Dockerfile
+++ b/logstash-verifier/Dockerfile
@@ -1,5 +1,5 @@
-ARG LS_VER
-FROM logstash:${LS_VER}
+# sha256 of 6.7.1 as of 2020-07-09
+FROM logstash@sha256:a4e3964f275dccd00f01f4536115785e1148d46be61282da316b6b6b654676a4
 
 LABEL MAINTAINER="Freedom of the Press"
 

--- a/logstash-verifier/Dockerfile
+++ b/logstash-verifier/Dockerfile
@@ -1,29 +1,17 @@
-FROM openjdk:8-jdk-slim-stretch
-
-MAINTAINER Freedom of the Press
-
-ENV LS_VERIFIER_TAR https://github.com/magnusbaeck/logstash-filter-verifier/releases/download/1.4.1/logstash-filter-verifier_1.4.1_linux_amd64.tar.gz
-ENV LS_VERIFIER_SHA256 2c322c84d5a82532ee7aee56f06bb1046b62fe46a73e920be970301382decaf1
 ARG LS_VER
+FROM logstash:${LS_VER}
 
+LABEL MAINTAINER="Freedom of the Press"
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl gnupg2 apt-transport-https && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/*
+ENV LS_VERIFIER_TAR https://github.com/magnusbaeck/logstash-filter-verifier/releases/download/1.5.0/logstash-filter-verifier_1.5.0_linux_amd64.tar.gz
+ENV LS_VERIFIER_SHA256 9afbac697f87ec2e1773d2863e68bddd72b6d3f1d825334d62720dbc51a98b0e
 
-RUN curl -fs https://packages.elastic.co/GPG-KEY-elasticsearch | apt-key add - && \
-    echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" > /etc/apt/sources.list.d/elastic.list && \
-    apt-get update && apt-get install logstash=1:${LS_VER}-1 && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/*
-
+USER root
 RUN cd /tmp && \
     curl -sL $LS_VERIFIER_TAR -o ls-verifier.tar.gz && \
-    echo "$LS_VERIFIER_SHA256 ls-verifier.tar.gz" | sha256sum -c - && \
-    tar -C /usr/bin -xzf ls-verifier.tar.gz
-
-RUN chown logstash: -R /etc/logstash
+    echo "$LS_VERIFIER_SHA256  ls-verifier.tar.gz" | sha256sum -c - && \
+    tar -C /usr/bin -xzf ls-verifier.tar.gz && \
+    rm ls-verifier.tar.gz
 
 ADD scripts/start-up.sh /run/startup.sh
 RUN chmod +x /run/startup.sh

--- a/logstash-verifier/meta.yml
+++ b/logstash-verifier/meta.yml
@@ -1,5 +1,3 @@
 ---
 repo: "quay.io/freedomofpress/logstash-verifier"
 tag: "6.7.1"
-args:
-  LS_VER: "6.7.1"


### PR DESCRIPTION
Lets base our upstream on Logstash's official container - no reason to
continue to fold in ES. We can always use another ES container and
string them together with docker-compose if necessary.

Also bumped logstash-filter-verifier to 1.5.0