### PR TITLE
Create Debian Buster / Python3 circleci-docker container for CI

### DIFF
--- a/circleci-docker-python3/Dockerfile
+++ b/circleci-docker-python3/Dockerfile
@@ -1,0 +1,19 @@
+# debian:buster-20191014
+FROM debian@sha256:41f76363fd83982e14f7644486e1fb04812b3894aa4e396137c3435eaf05de88
+
+
+ENV DOCKER_VER 19.03.4
+ENV DOCKER_SHA256_x86_64 efef2ad32d262674501e712351be0df9dd31d6034b175d0020c8f5d5c9c3fd10
+
+
+RUN apt-get update && \
+    apt-get install -y flake8 make virtualenv ccontrol libpython3.7-dev \
+            libffi-dev libssl-dev libyaml-dev python3-pip curl git &&\
+    apt-get clean
+
+RUN curl -L -o /tmp/docker-${DOCKER_VER}.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz; \
+	echo "${DOCKER_SHA256_x86_64} /tmp/docker-${DOCKER_VER}.tgz" | sha256sum -c -; \
+	cd /tmp && tar -xz -f /tmp/docker-${DOCKER_VER}.tgz; \
+	mv /tmp/docker/* /usr/bin
+
+CMD /bin/bash

--- a/circleci-docker-python3/meta.yml
+++ b/circleci-docker-python3/meta.yml
@@ -1,0 +1,3 @@
+---
+repo: "quay.io/freedomofpress/circleci-docker-python3"
+tag: "buster-19.03.4"


### PR DESCRIPTION
With python2 support being dropped at the end of the year, some python package versions no longer work on python2. We should create a new circleci-docker container to support python 3.7 (and update to buster). Updating the existing container may be problematic and introduce CI failures for repositories that use this container and don't pin a tag.

This container is required to get CI passing in https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/51 passing.

Observe the attempts and failures in https://circleci.com/gh/freedomofpress/ansible-role-grsecurity-build/tree/ansible-update