### PR TITLE
Catch exception running gcloud auth, log output and exit code

### DIFF
--- a/gke-gs-bucket-backup/gs_bucket_sync.py
+++ b/gke-gs-bucket-backup/gs_bucket_sync.py
@@ -55,9 +55,15 @@ class GCPBucketBackup(object):
 
         if shellmode:
             cmd = " ".join(cmd)
-        copy_output = subprocess.check_output(
-            cmd, stderr=subprocess.STDOUT, shell=shellmode).decode('ascii')
-        logger.debug(copy_output)
+
+        try:
+            copy_output = subprocess.check_output(
+                cmd, stderr=subprocess.STDOUT, shell=shellmode).decode('ascii')
+            logger.debug(copy_output)
+        except subprocess.CalledProcessError as e:
+            logger.error("command {} failed with status {}, output = {}".format(
+                e.cmd, e.returncode, e.output))
+            sys.exit(1)
 
         return copy_output
 

--- a/gke-gs-bucket-backup/meta.yml
+++ b/gke-gs-bucket-backup/meta.yml
@@ -1,0 +1,3 @@
+---
+repo: "quay.io/freedomofpress/gke-gs-bucket-backup"
+tag: "latest"


### PR DESCRIPTION
This container's script was failing due to a read-only fs, but only with a traceback:

```
Traceback (most recent call last):                                                                                                                            
  File "/usr/local/bin/gs_bucket_sync.py", line 159, in <module>                                                                                              
    backup.initialize_svc_acct(parsed_args.svc_act_key)                                                                                                       
  File "/usr/local/bin/gs_bucket_sync.py", line 69, in initialize_svc_acct                                                                                    
    self._subprocess_debug_wrap(gcloud_auth_cmd)                                                                                                              
  File "/usr/local/bin/gs_bucket_sync.py", line 59, in _subprocess_debug_wrap                                                                                      cmd, stderr=subprocess.STDOUT, shell=shellmode).decode('ascii')                                                                                           
  File "/usr/lib/python3.5/subprocess.py", line 316, in check_output                                                                                          
    **kwargs).stdout                                                                                                                                          
  File "/usr/lib/python3.5/subprocess.py", line 398, in run                                                                                                   
    output=stdout, stderr=stderr)                                                                                                                             
subprocess.CalledProcessError: Command '['gcloud', 'auth', 'activate-service-account', '--key-file', '/secrets/GS_BUCKET_SVC_ACCT.json']' returned non-zero exi
t status 1    
```

Catch and log, so it looks like:

```
command ['gcloud', 'auth', 'activate-service-account', '--key-file', '/secrets/GS_BUCKET_SVC_ACCT.json'] failed with status 1, output = b"WARNING: Could not setup log file in /home/gcloud_user/.config/gcloud/logs, (OSError: [Errno 30] Read-only file system: '/home/gcloud_user/.config')\nERROR: (gcloud.auth.activate-service-account) Unable to create private file [/home/gcloud_user/.config/gcloud/credentials.db]: [Errno 30] Read-only file system: '/home/gcloud_user/.config'\n"
```