### PR TITLE
Update gcloud-sdk to 298.0.0-slim, do not add nonexistent dir to PATH

### DIFF
--- a/gke-gs-bucket-backup/Dockerfile
+++ b/gke-gs-bucket-backup/Dockerfile
@@ -1,13 +1,9 @@
-# tag 258.0.0
-ARG CLOUD_SDK_HASH='d026fcb44de9f3ac58ed959afa892d8216de858dc69b370e001d641a4e362437'
-
-FROM google/cloud-sdk@sha256:${CLOUD_SDK_HASH}
+# sha256 as of 2020-06-30 for 298.0.0-slim
+FROM google/cloud-sdk@sha256:eaf964b5ac31bb7cc833c39c8c29a9002f9ec4c45311e9a66771cc5570a73723
 
 COPY gs_bucket_sync.py /usr/local/bin
 
-RUN adduser --disabled-password --gecos "" gcloud_user
+RUN adduser --disabled-password --uid 1000 gcloud_user
 USER gcloud_user
-ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
-
 
 ENTRYPOINT [ "/usr/local/bin/gs_bucket_sync.py" ]


### PR DESCRIPTION
Tag pin update! The gcloud-sdk container puts its executable in PATH; if an old version used `/opt` it no longer does.

We were previously depending in the k8s backup job config on our added user being UID 1000, let's be explicit about that.
