### PR TITLE
Update logstash base to 6.7.2

### DIFF
--- a/logstash-verifier/Dockerfile
+++ b/logstash-verifier/Dockerfile
@@ -1,5 +1,5 @@
-# sha256 of 6.7.1 as of 2020-07-09
-FROM logstash@sha256:a4e3964f275dccd00f01f4536115785e1148d46be61282da316b6b6b654676a4
+# sha256 of logstash:6.7.2 as of 2020-07-09
+FROM logstash@sha256:857d9a1f822101fe076e6e6a4a7df0426640424521e868393dac7e171baa9af5
 
 LABEL MAINTAINER="Freedom of the Press"
 


### PR DESCRIPTION
This is the last available version of 6.7; according to the Docker Hub page only 6.8 is actually supported. That will be resolved by https://github.com/freedomofpress/infrastructure/issues/2716. For now just want to put building containers out of this repo through its paces.