### PR TITLE
Fix logstash base digest

### DIFF
--- a/logstash-verifier/Dockerfile
+++ b/logstash-verifier/Dockerfile
@@ -1,5 +1,5 @@
-# sha256 as of 2020-07-09 for logstash:6.7.2
-FROM logstash@sha256:857d9a1f822101fe076e6e6a4a7df0426640424521e868393dac7e171baa9af5
+# sha256 as of 2020-08-03 for 6.7.2
+FROM logstash@sha256:876161bea60a92c77080a55cb9764e9ffeb069c4bc0e2a1b763ef4ced51ba6ad
 
 LABEL MAINTAINER="Freedom of the Press"
 


### PR DESCRIPTION
It looks like this image for the 6.7.2 tag was removed:

```
$ docker run -it --rm logstash@sha256:857d9a1f822101fe076e6e6a4a7df0426640424521e868393dac7e171baa9af5
Unable to find image 'logstash@sha256:857d9a1f822101fe076e6e6a4a7df0426640424521e868393dac7e171baa9af5' locally
docker: Error response from daemon: received unexpected HTTP status: 500 Internal Server Error.
```

CI can't pull it either.